### PR TITLE
gracefully handle when calibration aruco marker is not detected

### DIFF
--- a/easy_handeye2/easy_handeye2/handeye_client.py
+++ b/easy_handeye2/easy_handeye2/handeye_client.py
@@ -65,7 +65,10 @@ class HandeyeClient:
     # services: sampling
 
     def get_current_transforms(self):
-        return self.get_current_transforms_client.call(ehm.srv.TakeSample.Request()).samples.samples[0]
+        samples = self.get_current_transforms_client.call(ehm.srv.TakeSample.Request()).samples
+        if samples.samples:
+            return samples.samples[0]
+        return None
 
     def get_sample_list(self):
         return self.get_sample_client.call(ehm.srv.TakeSample.Request()).samples

--- a/easy_handeye2/easy_handeye2/handeye_rqt_calibrator_widget.py
+++ b/easy_handeye2/easy_handeye2/handeye_rqt_calibrator_widget.py
@@ -185,8 +185,7 @@ class RqtHandeyeCalibratorWidget(QWidget):
         rotation_has_moved = RqtHandeyeCalibratorWidget._rotation_distance(t1, t2) > ROTATION_TOLERANCE_RAD
         return translation_has_moved or rotation_has_moved
 
-    def _check_still_moving(self):
-        new_transforms = self.client.get_current_transforms()
+    def _check_still_moving(self, new_transforms):
         if self._current_transforms is None:
             self._current_transforms = new_transforms
             return False
@@ -200,7 +199,8 @@ class RqtHandeyeCalibratorWidget(QWidget):
         return robot_is_moving or tracking_is_moving
 
     def _updateUI(self):
-        if self._check_still_moving():
+        new_transforms = self.client.get_current_transforms()
+        if new_transforms is None or self._check_still_moving(new_transforms):
             self._widget.takeButton.setEnabled(False)
         else:
             self._widget.takeButton.setEnabled(True)

--- a/easy_handeye2/easy_handeye2/handeye_sampler.py
+++ b/easy_handeye2/easy_handeye2/handeye_sampler.py
@@ -84,7 +84,7 @@ class HandeyeSampler:
         self.node.get_logger().info('All expected transforms are available on tf; ready to take samples')
         return True
 
-    def _get_transforms(self, time: Optional[rclpy.time.Time] = None) -> easy_handeye2_msgs.msg.Sample:
+    def _get_transforms(self, time: Optional[rclpy.time.Time] = None) -> Sample:
         """
         Samples the transforms at the given time.
         """

--- a/easy_handeye2/easy_handeye2/handeye_server.py
+++ b/easy_handeye2/easy_handeye2/handeye_server.py
@@ -3,7 +3,9 @@ import itertools
 import rclpy
 import std_msgs
 import easy_handeye2_msgs as ehm
+from easy_handeye2_msgs import msg, srv
 from rclpy.executors import ExternalShutdownException
+from std_msgs import msg
 
 import easy_handeye2 as hec
 from easy_handeye2.handeye_calibration import save_calibration, HandeyeCalibrationParametersProvider


### PR DESCRIPTION
Addresses https://github.com/marcoesposito1988/easy_handeye2/issues/6

Implements:
- wait until all required TF frames are present before starting the GUI
- disables taking of samples instead of crash when the calibration aruco is not detected
- switch to using a `MultiThreadedExecutor` for better app responsiveness when calibration aruco is not detected.