### PR TITLE
Added default parameter to handle node crashing, also removed deprecated equal launch condition

### DIFF
--- a/easy_handeye2/easy_handeye2/common_launch.py
+++ b/easy_handeye2/easy_handeye2/common_launch.py
@@ -1,6 +1,7 @@
 
 from launch.actions import DeclareLaunchArgument
-from launch.conditions import LaunchConfigurationEquals
+from launch.substitutions import EqualsSubstitution, LaunchConfiguration
+from launch.conditions    import IfCondition
 
 
 arg_calibration_type = DeclareLaunchArgument('calibration_type', choices=["eye_in_hand", "eye_on_base"],
@@ -10,4 +11,16 @@ arg_tracking_marker_frame = DeclareLaunchArgument('tracking_marker_frame')
 arg_robot_base_frame = DeclareLaunchArgument('robot_base_frame')
 arg_robot_effector_frame = DeclareLaunchArgument('robot_effector_frame')
 
-is_eye_in_hand = LaunchConfigurationEquals('calibration_type', 'eye_in_hand')
+is_eye_in_hand = IfCondition(
+  EqualsSubstitution(
+    LaunchConfiguration('calibration_type'),
+    'eye_in_hand'
+  )
+)
+
+is_eye_on_base = IfCondition(
+  EqualsSubstitution(
+    LaunchConfiguration('calibration_type'),
+    'eye_on_base'
+  )
+)

--- a/easy_handeye2/easy_handeye2/handeye_calibration.py
+++ b/easy_handeye2/easy_handeye2/handeye_calibration.py
@@ -17,12 +17,12 @@ class HandeyeCalibrationParametersProvider:
     def __init__(self, node: Node):
         self.node = node
         # declare and read parameters
-        self.node.declare_parameter('name', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
-        self.node.declare_parameter('calibration_type', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
-        self.node.declare_parameter('robot_base_frame', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
-        self.node.declare_parameter('robot_effector_frame', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
-        self.node.declare_parameter('tracking_base_frame', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
-        self.node.declare_parameter('tracking_marker_frame', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
+        self.node.declare_parameter('name', '', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
+        self.node.declare_parameter('calibration_type', '', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
+        self.node.declare_parameter('robot_base_frame', '', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
+        self.node.declare_parameter('robot_effector_frame', '', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
+        self.node.declare_parameter('tracking_base_frame', '', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
+        self.node.declare_parameter('tracking_marker_frame', '', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
         self.node.declare_parameter('freehand_robot_movement', True)
 
     def read(self):

--- a/easy_handeye2/easy_handeye2/handeye_publisher.py
+++ b/easy_handeye2/easy_handeye2/handeye_publisher.py
@@ -12,7 +12,7 @@ class HandeyePublisher(rclpy.node.Node):
     def __init__(self):
         super().__init__('handeye_publisher')
 
-        self.declare_parameter('name', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
+        self.declare_parameter('name', '')
         name = self.get_parameter('name').get_parameter_value().string_value
 
         self.get_logger().info(f'Loading the calibration with name {name}')

--- a/easy_handeye2/easy_handeye2/handeye_rqt_evaluator_widget.py
+++ b/easy_handeye2/easy_handeye2/handeye_rqt_evaluator_widget.py
@@ -27,7 +27,7 @@ class RqtHandeyeEvaluatorWidget(QWidget):
         self._node = context.node
         # self.parameters_provider = HandeyeCalibrationParametersProvider(self._node)
         # self.parameters = self.parameters_provider.read()
-        self._node.declare_parameter('name', descriptor=ParameterDescriptor(type=ParameterType.PARAMETER_STRING))
+        self._node.declare_parameter('name', '')
         name = self._node.get_parameter('name').get_parameter_value().string_value
         self.calibration = load_calibration(name)
         self.parameters = self.calibration.parameters
@@ -156,14 +156,14 @@ class RqtHandeyeEvaluatorWidget(QWidget):
             # TODO: provide feedback if the data is sufficient
 
         except (LookupException, ExtrapolationException, ConnectivityException) as e:
-            self.node.get_logger().error(
+            self._node.get_logger().error(
                 'The specified tf frames for the robot base and hand do not seem to be connected')
-            self.node.get_logger().error('Run the following command and check its output:')
-            self.node.get_logger().error(
+            self._node.get_logger().error('Run the following command and check its output:')
+            self._node.get_logger().error(
                 f'ros2 run tf2_ros tf2_echo {self.robot_base_frame} {self.robot_effector_frame}')
-            self.node.get_logger().error(
+            self._node.get_logger().error(
                 f'You may need to correct the base_frame or effector_frame argument passed to the easy_handeye2 launch file')
-            self.node.get_logger().error(f'Underlying tf exception: {e}')
+            self._node.get_logger().error(f'Underlying tf exception: {e}')
             return False
 
     def reset(self):

--- a/easy_handeye2/launch/calibrate.launch.py
+++ b/easy_handeye2/launch/calibrate.launch.py
@@ -1,23 +1,23 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.conditions import LaunchConfigurationEquals
+from launch.substitutions import EqualsSubstitution
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
 
 from easy_handeye2.common_launch import arg_calibration_type, arg_tracking_base_frame, arg_tracking_marker_frame, arg_robot_base_frame, \
-    arg_robot_effector_frame
+    arg_robot_effector_frame, is_eye_in_hand, is_eye_on_base
 
 
 def generate_launch_description():
     arg_name = DeclareLaunchArgument('name')
 
     node_dummy_calib_eih = Node(package='tf2_ros', executable='static_transform_publisher', name='dummy_publisher',
-                                condition=LaunchConfigurationEquals('calibration_type', 'eye_in_hand'),
+                                condition=is_eye_in_hand,
                                 arguments=f'--x 0 --y 0 --z 0.1 --qx 0 --qy 0 --qz 0 --qw 1'.split(' ') + ['--frame-id', LaunchConfiguration('robot_effector_frame'),
                                                                                                            '--child-frame-id', LaunchConfiguration('tracking_base_frame')])
 
     node_dummy_calib_eob = Node(package='tf2_ros', executable='static_transform_publisher', name='dummy_publisher',
-                                condition=LaunchConfigurationEquals('calibration_type', 'eye_on_base'),
+                                condition=is_eye_on_base,
                                 arguments=f'--x 1 --y 0 --z 0 --qx 0 --qy 0 --qz 0 --qw 1'.split(' ') + ['--frame-id', LaunchConfiguration('robot_base_frame'),
                                                                                                          '--child-frame-id', LaunchConfiguration('tracking_base_frame')])
 


### PR DESCRIPTION
- Added default ` ` value to parameters in `HandeyeCalibrationsParameterProvider` to prevent node crashing, 
- Replaced deprecating `LaunchConfigurationEquals`  with `EqualsSubstitution`